### PR TITLE
feat(ui): add player movement controls and roster

### DIFF
--- a/frontend/src/lib/components/game/player-roster.svelte
+++ b/frontend/src/lib/components/game/player-roster.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+	import { flip } from 'svelte/animate';
+	import { slide } from 'svelte/transition';
+
 	export interface PlayerSummary {
 		id: string;
 		name: string;
-		status: 'ready' | 'ingame' | 'eliminated';
+		status: 'spectating' | 'ingame' | 'eliminated';
 		accent: string;
 	}
 
@@ -10,50 +13,112 @@
 		players: PlayerSummary[];
 	}
 
-	let { players }: Props = $props();
+	let { players = $bindable() }: Props = $props();
 
 	let totalPlayers = $derived(players.length);
-	let activePlayers = $derived(players.filter((player) => player.status !== 'eliminated').length);
+	let activePlayers = $derived(players.filter((player) => player.status === 'ingame').length);
+	let inactivePlayers = $derived(players.filter((player) => player.status !== 'ingame').length);
+	let sortedPlayers = $derived(
+		players.toSorted((a, b) => {
+			const statusOrder = { ingame: 0, eliminated: 1, spectating: 2 };
+			return statusOrder[a.status] - statusOrder[b.status];
+		})
+	);
 </script>
 
-<aside class="w-full max-w-full space-y-6 rounded-3xl border-4 border-black bg-slate-950/85 p-6 shadow-[0_12px_0px_rgba(0,0,0,0.55)] backdrop-blur lg:max-w-sm">
+<aside
+	class="w-full max-w-full space-y-6 rounded-3xl border-4 border-black bg-slate-950/85 p-6 shadow-[0_12px_0px_rgba(0,0,0,0.55)] backdrop-blur transition-all duration-300 lg:max-w-sm"
+>
 	<div class="space-y-1">
-		<h2 class="font-minecraft text-2xl uppercase tracking-wide text-cyan-300">Players</h2>
+		<h2 class="font-minecraft text-2xl tracking-wide text-cyan-300 uppercase">Players</h2>
 		<p class="text-sm text-blue-100/70">
 			Players sync in real-time once the lobby is live. Showing sample roster for styling.
 		</p>
 	</div>
 
-	<div class="flex items-center justify-between rounded-lg border-2 border-black bg-gradient-to-r from-emerald-500/20 via-transparent to-cyan-500/20 px-4 py-3 text-xs uppercase tracking-[0.25em] text-blue-100/60">
+	<div
+		class="flex items-center justify-between rounded-lg border-2 border-black bg-gradient-to-r from-emerald-500/20 via-transparent to-cyan-500/20 px-4 py-3 text-xs tracking-[0.25em] text-blue-100/60 uppercase"
+	>
 		<span>{activePlayers} active</span>
 		<span>{totalPlayers} total</span>
 	</div>
 
-	<ul class="space-y-3">
-		{#each players as player (player.id)}
-			<li class="pixel-card flex items-center justify-between gap-3 rounded-xl border-2 border-black bg-slate-900/80 px-4 py-3 shadow-[4px_4px_0px_rgba(0,0,0,0.6)]">
+	<div class="space-y-3">
+		{#each sortedPlayers as player, index (player.id)}
+			<div animate:flip={{ duration: 300, easing: (t) => t * (2 - t) }}>
+				<!-- Separator between active and inactive players -->
+				{#if index > 0 && sortedPlayers[index - 1].status === 'ingame' && player.status !== 'ingame' && activePlayers > 0 && inactivePlayers > 0}
+					<div
+						class="mb-3 h-px bg-gradient-to-r from-transparent via-slate-600/50 to-transparent"
+						transition:slide={{ duration: 300, axis: 'y' }}
+					></div>
+				{/if}
+
+				<div
+					class="pixel-card flex items-center justify-between gap-3 rounded-xl border-2 border-black {player.status ===
+					'ingame'
+						? 'bg-slate-900/80'
+						: 'bg-slate-900/50 opacity-75'} px-4 py-3 shadow-[4px_4px_0px_rgba(0,0,0,0.6)] transition-all duration-500 ease-in-out"
+				>
 				<div class="flex items-center gap-3">
 					<span
-						class={`h-10 w-10 rounded-lg border-2 border-black bg-gradient-to-br ${player.accent} shadow-[2px_2px_0px_rgba(0,0,0,0.5)]`}
+						class={`h-10 w-10 rounded-lg border-2 border-black bg-gradient-to-br ${player.accent} shadow-[2px_2px_0px_rgba(0,0,0,0.5)] ${player.status !== 'ingame' ? 'grayscale' : ''} transition-all duration-500 ease-in-out`}
 					></span>
 					<div>
-						<p class="font-minecraft text-lg uppercase tracking-wide text-yellow-100">
+						<p
+							class="font-minecraft text-lg tracking-wide text-yellow-100 uppercase {player.status !==
+							'ingame'
+								? 'opacity-70'
+								: ''} transition-all duration-500 ease-in-out"
+						>
 							{player.name}
 						</p>
-						<p class={`text-xs uppercase tracking-[0.25em] ${player.status === 'eliminated' ? 'text-rose-300/70' : player.status === 'ingame' ? 'text-emerald-200/80' : 'text-blue-100/70'}`}>
-							{player.status === 'ingame' ? 'On Mission' : player.status === 'ready' ? 'Ready' : 'Eliminated'}
-						</p>
+						{#if player.status === 'eliminated'}
+							<p
+								class="text-xs tracking-[0.25em] text-rose-300/70 uppercase transition-all duration-500 ease-in-out"
+							>
+								Eliminated
+							</p>
+						{:else if player.status === 'ingame'}
+							<p
+								class="text-xs tracking-[0.25em] text-emerald-200/80 uppercase transition-all duration-500 ease-in-out"
+							>
+								On Mission
+							</p>
+						{:else if player.status === 'spectating'}
+							<p
+								class="text-xs tracking-[0.25em] text-blue-100/70 uppercase transition-all duration-500 ease-in-out"
+							>
+								Spectating
+							</p>
+						{/if}
 					</div>
 				</div>
 				<button
-					class="rounded-md border-2 border-black bg-slate-800/80 px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em] text-blue-100/70 shadow-[2px_2px_0px_rgba(0,0,0,0.45)] transition-colors hover:bg-slate-700"
+					class="cursor-pointer rounded-md border-2 border-black {player.status ===
+					'ingame'
+						? 'bg-slate-800/80'
+						: 'bg-slate-800/50'} px-3 py-1 text-[0.65rem] tracking-[0.3em] {player.status ===
+					'ingame'
+						? 'text-blue-100/70'
+						: 'text-blue-100/50'} uppercase shadow-[2px_2px_0px_rgba(0,0,0,0.45)] transition-all duration-500 ease-in-out hover:bg-slate-700"
 					type="button"
+					disabled={player.status !== 'ingame'}
+					onclick={() => {
+						if (player.status === 'ingame') {
+							const originalIndex = players.findIndex((p) => p.id === player.id);
+							if (originalIndex !== -1) {
+								players[originalIndex].status = 'eliminated';
+							}
+						}
+					}}
 				>
-					Inspect
+					Kill
 				</button>
-			</li>
+				</div>
+			</div>
 		{/each}
-	</ul>
+	</div>
 </aside>
 
 <style>

--- a/frontend/src/routes/game/[gameId]/+page.svelte
+++ b/frontend/src/routes/game/[gameId]/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import GameBoardPanel from '$lib/components/game/game-board-panel.svelte';
+	import PlayerMovementControls, {
+		type Direction
+	} from '$lib/components/game/player-movement-controls.svelte';
 	import PlayerRoster, { type PlayerSummary } from '$lib/components/game/player-roster.svelte';
 
 	interface Props {
@@ -11,18 +14,35 @@
 	let { params }: Props = $props();
 	let mapSize = $state(18);
 	let players = $state<PlayerSummary[]>([
-		{ id: '1', name: 'PixelPanda', status: 'ready', accent: 'from-emerald-400 to-emerald-600' },
+		{
+			id: '1',
+			name: 'PixelPanda',
+			status: 'ingame',
+			accent: 'from-emerald-400 to-emerald-600'
+		},
 		{ id: '2', name: 'ShadowFox', status: 'ingame', accent: 'from-blue-400 to-indigo-600' },
-		{ id: '3', name: 'NeonNova', status: 'ready', accent: 'from-pink-400 to-rose-600' },
+		{ id: '3', name: 'NeonNova', status: 'spectating', accent: 'from-pink-400 to-rose-600' },
 		{ id: '4', name: 'ByteKnight', status: 'eliminated', accent: 'from-slate-500 to-slate-700' }
 	]);
+
+	let lastMove = $state<Direction | null>(null);
+
+	function handlePlayerMove(direction: Direction) {
+		lastMove = direction;
+	}
+
+	$inspect(players);
 </script>
 
 <div class="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 text-white">
 	<div class="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 sm:py-12">
 		<header class="flex flex-col gap-3 text-center lg:text-left">
-			<p class="text-sm uppercase tracking-[0.35em] text-blue-200/80">Blind Party Prototype</p>
-			<h1 class="font-minecraft text-3xl uppercase tracking-wider text-yellow-300 drop-shadow-[4px_4px_0px_rgba(0,0,0,0.65)] sm:text-4xl">
+			<p class="text-sm tracking-[0.35em] text-blue-200/80 uppercase">
+				Blind Party Prototype
+			</p>
+			<h1
+				class="font-minecraft text-3xl tracking-wider text-yellow-300 uppercase drop-shadow-[4px_4px_0px_rgba(0,0,0,0.65)] sm:text-4xl"
+			>
 				Game ID: <span class="text-white">{params.gameId}</span>
 			</h1>
 			<p class="text-base text-blue-100/80">


### PR DESCRIPTION
- import wire PlayerMovementControls into game page and expose last
  input state; add handlePlayerMove to capture directions and display the
  last input below the board for quick feedback.
- bind players prop on PlayerRoster so the roster reflects live updates
  made from the parent page.
- adjust sample players statuses (ready -> ingame/spectating) to match
  updated status set and demo state.
- refine header markup and classes for consistent ordering and spacing.
- add $inspect(players) for easier runtime inspection during development.
- extend PlayerSummary status union to include "spectating" and update
  roster logic:
  - compute activePlayers (ingame) and inactivePlayers counts,
  - derive sortedPlayers to order roster by status (ingame, eliminated,
    spectating).
- add entrance/flip animations and transition classes to roster aside,
  and tweak text/class ordering for consistent styling.

Motivation:
- Provide immediate UI feedback for player inputs and support spectating
  state. Improve reactivity and visual polish of the player roster to
  better reflect live game state and developer debugging needs.