### PR TITLE
feat(ui): make player movement controls responsive

### DIFF
--- a/frontend/src/routes/game/[gameId]/+page.svelte
+++ b/frontend/src/routes/game/[gameId]/+page.svelte
@@ -50,9 +50,16 @@
 
 		<div class="flex flex-col gap-8 lg:flex-row">
 			<GameBoardPanel {mapSize} />
+			<!-- Show movement controls between board and roster on mobile -->
+			<div class="lg:hidden">
+				<PlayerMovementControls onMove={handlePlayerMove} />
+			</div>
 			<PlayerRoster bind:players />
 		</div>
 
-		<PlayerMovementControls onMove={handlePlayerMove} />
+		<!-- Keep the original controls visible only on large screens (desktop) -->
+		<div class="hidden lg:block">
+			<PlayerMovementControls onMove={handlePlayerMove} />
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
Place PlayerMovementControls between the board and roster on small
screens and keep the original placement visible only on large screens.
This moves the controls into a lg:hidden wrapper for mobile and into a
hidden lg:block wrapper for desktop.

Improve layout and usability on mobile so movement controls appear
between the board and roster, matching expected visual flow.