### PR TITLE
feat(player): move direction logic into shared playerState

### DIFF
--- a/frontend/src/lib/components/game/player-movement-controls.svelte
+++ b/frontend/src/lib/components/game/player-movement-controls.svelte
@@ -1,188 +1,188 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { playerState, type Direction } from '$lib/player-state.svelte.js';
+    import { onMount } from 'svelte';
+    import { playerState, type Direction } from '$lib/player-state.svelte.js';
 
-	interface Props {
-		disabled?: boolean;
-	}
+    interface Props {
+        disabled?: boolean;
+    }
 
-	let { disabled = false }: Props = $props();
+    let { disabled = false }: Props = $props();
 
-	function handlePointerDown(direction: Direction, event: PointerEvent) {
-		if (disabled) {
-			return;
-		}
+    function handlePointerDown(direction: Direction, event: PointerEvent) {
+        if (disabled) {
+            return;
+        }
 
-		event.preventDefault();
-		playerState.triggerMove(direction);
-	}
+        event.preventDefault();
+        playerState.triggerMove(direction);
+    }
 
-	function handlePointerEnd(direction: Direction, event: PointerEvent) {
-		if (disabled) {
-			return;
-		}
+    function handlePointerEnd(direction: Direction, event: PointerEvent) {
+        if (disabled) {
+            return;
+        }
 
-		event.preventDefault();
-		playerState.clearDirection(direction);
-	}
+        event.preventDefault();
+        playerState.clearDirection(direction);
+    }
 
-	onMount(() => {
-		function handleKeyDown(event: KeyboardEvent) {
-			if (disabled) {
-				return;
-			}
-			playerState.handleKeyDown(event);
-		}
+    onMount(() => {
+        function handleKeyDown(event: KeyboardEvent) {
+            if (disabled) {
+                return;
+            }
+            playerState.handleKeyDown(event);
+        }
 
-		function handleKeyUp(event: KeyboardEvent) {
-			playerState.handleKeyUp(event);
-		}
+        function handleKeyUp(event: KeyboardEvent) {
+            playerState.handleKeyUp(event);
+        }
 
-		window.addEventListener('keydown', handleKeyDown);
-		window.addEventListener('keyup', handleKeyUp);
+        window.addEventListener('keydown', handleKeyDown);
+        window.addEventListener('keyup', handleKeyUp);
 
-		return () => {
-			window.removeEventListener('keydown', handleKeyDown);
-			window.removeEventListener('keyup', handleKeyUp);
-			playerState.clearPressedKeys();
-		};
-	});
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.removeEventListener('keyup', handleKeyUp);
+            playerState.clearPressedKeys();
+        };
+    });
 </script>
 
 <section
-	class="movement-panel w-full rounded-3xl border-4 border-black bg-slate-950/85 px-6 py-8 text-blue-100 shadow-[0_16px_0px_rgba(0,0,0,0.55)] backdrop-blur"
-	aria-label="Player movement controls"
+    class="movement-panel w-full rounded-3xl border-4 border-black bg-slate-950/85 px-6 py-8 text-blue-100 shadow-[0_16px_0px_rgba(0,0,0,0.55)] backdrop-blur"
+    aria-label="Player movement controls"
 >
-	<div class="flex flex-col items-center gap-6">
-		<div
-			class="flex w-full flex-col items-start justify-between gap-2 sm:flex-row sm:items-center"
-		>
-			<h2 class="font-minecraft text-xl tracking-[0.35em] text-cyan-200 uppercase">
-				Movement
-			</h2>
-			<p class="text-xs tracking-[0.3em] text-blue-200/70 uppercase">
-				Use Arrow Keys or WASD
-			</p>
-		</div>
+    <div class="flex flex-col items-center gap-6">
+        <div
+            class="flex w-full flex-col items-start justify-between gap-2 sm:flex-row sm:items-center"
+        >
+            <h2 class="font-minecraft text-xl tracking-[0.35em] text-cyan-200 uppercase">
+                Movement
+            </h2>
+            <p class="text-xs tracking-[0.3em] text-blue-200/70 uppercase">
+                Use Arrow Keys or WASD
+            </p>
+        </div>
 
-		<div class="grid w-full max-w-sm grid-cols-3 grid-rows-3 gap-3">
-			<div></div>
-			<button
-				type="button"
-				class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
-					playerState.activeDirections.has('up')
-						? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
-						: 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
-				} focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
-				onpointerdown={(event) => handlePointerDown('up', event)}
-				onpointerup={(event) => handlePointerEnd('up', event)}
-				onpointerleave={(event) => handlePointerEnd('up', event)}
-				onpointercancel={(event) => handlePointerEnd('up', event)}
-				aria-label="Move up"
-			>
-				<svg
-					viewBox="0 0 24 24"
-					fill="currentColor"
-					aria-hidden="true"
-					class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
-				>
-					<path d="M12 5.5 5 13h4v6h6v-6h4z" />
-				</svg>
-			</button>
-			<div></div>
+        <div class="grid w-full max-w-sm grid-cols-3 grid-rows-3 gap-3">
+            <div></div>
+            <button
+                type="button"
+                class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
+                    playerState.activeDirections.has('up')
+                        ? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
+                        : 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
+                } focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
+                onpointerdown={(event) => handlePointerDown('up', event)}
+                onpointerup={(event) => handlePointerEnd('up', event)}
+                onpointerleave={(event) => handlePointerEnd('up', event)}
+                onpointercancel={(event) => handlePointerEnd('up', event)}
+                aria-label="Move up"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
+                >
+                    <path d="M12 5.5 5 13h4v6h6v-6h4z" />
+                </svg>
+            </button>
+            <div></div>
 
-			<button
-				type="button"
-				class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
-					playerState.activeDirections.has('left')
-						? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
-						: 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
-				} focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
-				onpointerdown={(event) => handlePointerDown('left', event)}
-				onpointerup={(event) => handlePointerEnd('left', event)}
-				onpointerleave={(event) => handlePointerEnd('left', event)}
-				onpointercancel={(event) => handlePointerEnd('left', event)}
-				aria-label="Move left"
-			>
-				<svg
-					viewBox="0 0 24 24"
-					fill="currentColor"
-					aria-hidden="true"
-					class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
-				>
-					<path d="M5.5 12 13 19v-4h6v-6h-6V5z" />
-				</svg>
-			</button>
+            <button
+                type="button"
+                class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
+                    playerState.activeDirections.has('left')
+                        ? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
+                        : 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
+                } focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
+                onpointerdown={(event) => handlePointerDown('left', event)}
+                onpointerup={(event) => handlePointerEnd('left', event)}
+                onpointerleave={(event) => handlePointerEnd('left', event)}
+                onpointercancel={(event) => handlePointerEnd('left', event)}
+                aria-label="Move left"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
+                >
+                    <path d="M5.5 12 13 19v-4h6v-6h-6V5z" />
+                </svg>
+            </button>
 
-			<button
-				type="button"
-				class="pointer-events-none inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black bg-slate-900/80 text-blue-200/50 opacity-50 shadow-none"
-				disabled
-				aria-hidden="true"
-			>
-				<span class="text-[0.6rem] tracking-[0.3em] uppercase">Move</span>
-			</button>
+            <button
+                type="button"
+                class="pointer-events-none inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black bg-slate-900/80 text-blue-200/50 opacity-50 shadow-none"
+                disabled
+                aria-hidden="true"
+            >
+                <span class="text-[0.6rem] tracking-[0.3em] uppercase">Move</span>
+            </button>
 
-			<button
-				type="button"
-				class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
-					playerState.activeDirections.has('right')
-						? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
-						: 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
-				} focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
-				onpointerdown={(event) => handlePointerDown('right', event)}
-				onpointerup={(event) => handlePointerEnd('right', event)}
-				onpointerleave={(event) => handlePointerEnd('right', event)}
-				onpointercancel={(event) => handlePointerEnd('right', event)}
-				aria-label="Move right"
-			>
-				<svg
-					viewBox="0 0 24 24"
-					fill="currentColor"
-					aria-hidden="true"
-					class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
-				>
-					<path d="M18.5 12 11 5v4H5v6h6v4z" />
-				</svg>
-			</button>
+            <button
+                type="button"
+                class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
+                    playerState.activeDirections.has('right')
+                        ? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
+                        : 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
+                } focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
+                onpointerdown={(event) => handlePointerDown('right', event)}
+                onpointerup={(event) => handlePointerEnd('right', event)}
+                onpointerleave={(event) => handlePointerEnd('right', event)}
+                onpointercancel={(event) => handlePointerEnd('right', event)}
+                aria-label="Move right"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
+                >
+                    <path d="M18.5 12 11 5v4H5v6h6v4z" />
+                </svg>
+            </button>
 
-			<div></div>
-			<button
-				type="button"
-				class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
-					playerState.activeDirections.has('down')
-						? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
-						: 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
-				} focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
-				onpointerdown={(event) => handlePointerDown('down', event)}
-				onpointerup={(event) => handlePointerEnd('down', event)}
-				onpointerleave={(event) => handlePointerEnd('down', event)}
-				onpointercancel={(event) => handlePointerEnd('down', event)}
-				aria-label="Move down"
-			>
-				<svg
-					viewBox="0 0 24 24"
-					fill="currentColor"
-					aria-hidden="true"
-					class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
-				>
-					<path d="M12 18.5 19 11h-4V5H9v6H5z" />
-				</svg>
-			</button>
-			<div></div>
-		</div>
+            <div></div>
+            <button
+                type="button"
+                class={`inline-flex h-16 w-16 items-center justify-center rounded-2xl border-3 border-black text-xs tracking-wider text-blue-100 uppercase transition-all duration-100 ease-in-out ${
+                    playerState.activeDirections.has('down')
+                        ? 'translate-y-0.5 bg-gradient-to-br from-red-400/60 to-red-600/80 text-orange-50 shadow-[2px_2px_0_rgba(0,0,0,0.6)]'
+                        : 'bg-gradient-to-br from-blue-400/40 to-blue-600/75 shadow-[4px_4px_0_rgba(0,0,0,0.55)] hover:shadow-[3px_3px_0_rgba(0,0,0,0.6)]'
+                } focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-white/85`}
+                onpointerdown={(event) => handlePointerDown('down', event)}
+                onpointerup={(event) => handlePointerEnd('down', event)}
+                onpointerleave={(event) => handlePointerEnd('down', event)}
+                onpointercancel={(event) => handlePointerEnd('down', event)}
+                aria-label="Move down"
+            >
+                <svg
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                    class="h-5 w-5 drop-shadow-[2px_2px_0_rgba(0,0,0,0.4)]"
+                >
+                    <path d="M12 18.5 19 11h-4V5H9v6H5z" />
+                </svg>
+            </button>
+            <div></div>
+        </div>
 
-		<p class="text-xs text-blue-200/60">
-			Tap or press directions to queue moves. Multiple keys can be pressed simultaneously.
-			Keyboard input works even when the buttons are not focused.
-		</p>
-	</div>
+        <p class="text-xs text-blue-200/60">
+            Tap or press directions to queue moves. Multiple keys can be pressed simultaneously.
+            Keyboard input works even when the buttons are not focused.
+        </p>
+    </div>
 </section>
 
 <style>
-	.movement-panel {
-		text-rendering: optimizeSpeed;
-		-webkit-font-smoothing: none;
-		-moz-osx-font-smoothing: grayscale;
-	}
+    .movement-panel {
+        text-rendering: optimizeSpeed;
+        -webkit-font-smoothing: none;
+        -moz-osx-font-smoothing: grayscale;
+    }
 </style>

--- a/frontend/src/lib/player-state.svelte.ts
+++ b/frontend/src/lib/player-state.svelte.ts
@@ -1,0 +1,75 @@
+import { SvelteSet } from 'svelte/reactivity';
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+/*
+Class storing our own player's state
+ **/
+class PlayerState {
+	activeDirections = $state<SvelteSet<Direction>>(new SvelteSet());
+	private pressedKeys = new Set<string>();
+
+	private keyDirectionMap: Record<string, Direction> = {
+		ArrowUp: 'up',
+		ArrowDown: 'down',
+		ArrowLeft: 'left',
+		ArrowRight: 'right',
+		w: 'up',
+		s: 'down',
+		a: 'left',
+		d: 'right'
+	};
+
+	private getDirectionFromKey(key: string): Direction | undefined {
+		if (!key) {
+			return undefined;
+		}
+
+		if (this.keyDirectionMap[key]) {
+			return this.keyDirectionMap[key];
+		}
+
+		const normalized = key.toLowerCase();
+		return this.keyDirectionMap[normalized];
+	}
+
+	triggerMove(direction: Direction) {
+		this.activeDirections.add(direction);
+	}
+
+	clearDirection(direction: Direction) {
+		this.activeDirections.delete(direction);
+	}
+
+	handleKeyDown(event: KeyboardEvent) {
+		const direction = this.getDirectionFromKey(event.key);
+		if (!direction) {
+			return;
+		}
+
+		if (this.pressedKeys.has(event.key)) {
+			event.preventDefault();
+			return;
+		}
+
+		this.pressedKeys.add(event.key);
+		event.preventDefault();
+		this.triggerMove(direction);
+	}
+
+	handleKeyUp(event: KeyboardEvent) {
+		const direction = this.getDirectionFromKey(event.key);
+		this.pressedKeys.delete(event.key);
+		if (!direction) {
+			return;
+		}
+
+		this.clearDirection(direction);
+	}
+
+	clearPressedKeys() {
+		this.pressedKeys.clear();
+	}
+}
+
+export const playerState = new PlayerState();

--- a/frontend/src/lib/player-state.svelte.ts
+++ b/frontend/src/lib/player-state.svelte.ts
@@ -6,70 +6,70 @@ export type Direction = 'up' | 'down' | 'left' | 'right';
 Class storing our own player's state
  **/
 class PlayerState {
-	activeDirections = $state<SvelteSet<Direction>>(new SvelteSet());
-	private pressedKeys = new Set<string>();
+    activeDirections = $state<SvelteSet<Direction>>(new SvelteSet());
+    private pressedKeys = new Set<string>();
 
-	private keyDirectionMap: Record<string, Direction> = {
-		ArrowUp: 'up',
-		ArrowDown: 'down',
-		ArrowLeft: 'left',
-		ArrowRight: 'right',
-		w: 'up',
-		s: 'down',
-		a: 'left',
-		d: 'right'
-	};
+    private keyDirectionMap: Record<string, Direction> = {
+        ArrowUp: 'up',
+        ArrowDown: 'down',
+        ArrowLeft: 'left',
+        ArrowRight: 'right',
+        w: 'up',
+        s: 'down',
+        a: 'left',
+        d: 'right'
+    };
 
-	private getDirectionFromKey(key: string): Direction | undefined {
-		if (!key) {
-			return undefined;
-		}
+    private getDirectionFromKey(key: string): Direction | undefined {
+        if (!key) {
+            return undefined;
+        }
 
-		if (this.keyDirectionMap[key]) {
-			return this.keyDirectionMap[key];
-		}
+        if (this.keyDirectionMap[key]) {
+            return this.keyDirectionMap[key];
+        }
 
-		const normalized = key.toLowerCase();
-		return this.keyDirectionMap[normalized];
-	}
+        const normalized = key.toLowerCase();
+        return this.keyDirectionMap[normalized];
+    }
 
-	triggerMove(direction: Direction) {
-		this.activeDirections.add(direction);
-	}
+    triggerMove(direction: Direction) {
+        this.activeDirections.add(direction);
+    }
 
-	clearDirection(direction: Direction) {
-		this.activeDirections.delete(direction);
-	}
+    clearDirection(direction: Direction) {
+        this.activeDirections.delete(direction);
+    }
 
-	handleKeyDown(event: KeyboardEvent) {
-		const direction = this.getDirectionFromKey(event.key);
-		if (!direction) {
-			return;
-		}
+    handleKeyDown(event: KeyboardEvent) {
+        const direction = this.getDirectionFromKey(event.key);
+        if (!direction) {
+            return;
+        }
 
-		if (this.pressedKeys.has(event.key)) {
-			event.preventDefault();
-			return;
-		}
+        if (this.pressedKeys.has(event.key)) {
+            event.preventDefault();
+            return;
+        }
 
-		this.pressedKeys.add(event.key);
-		event.preventDefault();
-		this.triggerMove(direction);
-	}
+        this.pressedKeys.add(event.key);
+        event.preventDefault();
+        this.triggerMove(direction);
+    }
 
-	handleKeyUp(event: KeyboardEvent) {
-		const direction = this.getDirectionFromKey(event.key);
-		this.pressedKeys.delete(event.key);
-		if (!direction) {
-			return;
-		}
+    handleKeyUp(event: KeyboardEvent) {
+        const direction = this.getDirectionFromKey(event.key);
+        this.pressedKeys.delete(event.key);
+        if (!direction) {
+            return;
+        }
 
-		this.clearDirection(direction);
-	}
+        this.clearDirection(direction);
+    }
 
-	clearPressedKeys() {
-		this.pressedKeys.clear();
-	}
+    clearPressedKeys() {
+        this.pressedKeys.clear();
+    }
 }
 
 export const playerState = new PlayerState();

--- a/frontend/src/routes/game/[gameId]/+page.svelte
+++ b/frontend/src/routes/game/[gameId]/+page.svelte
@@ -1,58 +1,57 @@
 <script lang="ts">
-	import GameBoardPanel from '$lib/components/game/game-board-panel.svelte';
-	import PlayerMovementControls from '$lib/components/game/player-movement-controls.svelte';
-	import PlayerRoster, { type PlayerSummary } from '$lib/components/game/player-roster.svelte';
+    import GameBoardPanel from '$lib/components/game/game-board-panel.svelte';
+    import PlayerMovementControls from '$lib/components/game/player-movement-controls.svelte';
+    import PlayerRoster, { type PlayerSummary } from '$lib/components/game/player-roster.svelte';
 
-	interface Props {
-		params: {
-			gameId: string;
-		};
-	}
+    interface Props {
+        params: {
+            gameId: string;
+        };
+    }
 
-	let { params }: Props = $props();
-	let mapSize = $state(18);
-	let players = $state<PlayerSummary[]>([
-		{
-			id: '1',
-			name: 'PixelPanda',
-			status: 'ingame',
-			accent: 'from-emerald-400 to-emerald-600'
-		},
-		{ id: '2', name: 'ShadowFox', status: 'ingame', accent: 'from-blue-400 to-indigo-600' },
-		{ id: '3', name: 'NeonNova', status: 'spectating', accent: 'from-pink-400 to-rose-600' },
-		{ id: '4', name: 'ByteKnight', status: 'eliminated', accent: 'from-slate-500 to-slate-700' }
-	]);
-
+    let { params }: Props = $props();
+    let mapSize = $state(18);
+    let players = $state<PlayerSummary[]>([
+        {
+            id: '1',
+            name: 'PixelPanda',
+            status: 'ingame',
+            accent: 'from-emerald-400 to-emerald-600'
+        },
+        { id: '2', name: 'ShadowFox', status: 'ingame', accent: 'from-blue-400 to-indigo-600' },
+        { id: '3', name: 'NeonNova', status: 'spectating', accent: 'from-pink-400 to-rose-600' },
+        { id: '4', name: 'ByteKnight', status: 'eliminated', accent: 'from-slate-500 to-slate-700' }
+    ]);
 </script>
 
 <div class="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 text-white">
-	<div class="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 sm:py-12">
-		<header class="flex flex-col gap-3 text-center lg:text-left">
-			<p class="text-sm tracking-[0.35em] text-blue-200/80 uppercase">
-				Blind Party Prototype
-			</p>
-			<h1
-				class="font-minecraft text-3xl tracking-wider text-yellow-300 uppercase drop-shadow-[4px_4px_0px_rgba(0,0,0,0.65)] sm:text-4xl"
-			>
-				Game ID: <span class="text-white">{params.gameId}</span>
-			</h1>
-			<p class="text-base text-blue-100/80">
-				Preview the arena layout and lobby roster while we hook up the live game feed.
-			</p>
-		</header>
+    <div class="mx-auto flex max-w-6xl flex-col gap-10 px-4 py-10 sm:px-6 sm:py-12">
+        <header class="flex flex-col gap-3 text-center lg:text-left">
+            <p class="text-sm tracking-[0.35em] text-blue-200/80 uppercase">
+                Blind Party Prototype
+            </p>
+            <h1
+                class="font-minecraft text-3xl tracking-wider text-yellow-300 uppercase drop-shadow-[4px_4px_0px_rgba(0,0,0,0.65)] sm:text-4xl"
+            >
+                Game ID: <span class="text-white">{params.gameId}</span>
+            </h1>
+            <p class="text-base text-blue-100/80">
+                Preview the arena layout and lobby roster while we hook up the live game feed.
+            </p>
+        </header>
 
-		<div class="flex flex-col gap-8 lg:flex-row">
-			<GameBoardPanel {mapSize} />
-			<!-- Show movement controls between board and roster on mobile -->
-			<div class="lg:hidden">
-				<PlayerMovementControls />
-			</div>
-			<PlayerRoster bind:players />
-		</div>
+        <div class="flex flex-col gap-8 lg:flex-row">
+            <GameBoardPanel {mapSize} />
+            <!-- Show movement controls between board and roster on mobile -->
+            <div class="lg:hidden">
+                <PlayerMovementControls />
+            </div>
+            <PlayerRoster bind:players />
+        </div>
 
-		<!-- Keep the original controls visible only on large screens (desktop) -->
-		<div class="hidden lg:block">
-			<PlayerMovementControls />
-		</div>
-	</div>
+        <!-- Keep the original controls visible only on large screens (desktop) -->
+        <div class="hidden lg:block">
+            <PlayerMovementControls />
+        </div>
+    </div>
 </div>

--- a/frontend/src/routes/game/[gameId]/+page.svelte
+++ b/frontend/src/routes/game/[gameId]/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import GameBoardPanel from '$lib/components/game/game-board-panel.svelte';
-	import PlayerMovementControls, {
-		type Direction
-	} from '$lib/components/game/player-movement-controls.svelte';
+	import PlayerMovementControls from '$lib/components/game/player-movement-controls.svelte';
 	import PlayerRoster, { type PlayerSummary } from '$lib/components/game/player-roster.svelte';
 
 	interface Props {
@@ -25,11 +23,6 @@
 		{ id: '4', name: 'ByteKnight', status: 'eliminated', accent: 'from-slate-500 to-slate-700' }
 	]);
 
-	let lastMove = $state<Direction | null>(null);
-
-	function handlePlayerMove(direction: Direction) {
-		lastMove = direction;
-	}
 </script>
 
 <div class="min-h-screen bg-gradient-to-br from-purple-900 via-blue-900 to-indigo-900 text-white">
@@ -52,14 +45,14 @@
 			<GameBoardPanel {mapSize} />
 			<!-- Show movement controls between board and roster on mobile -->
 			<div class="lg:hidden">
-				<PlayerMovementControls onMove={handlePlayerMove} />
+				<PlayerMovementControls />
 			</div>
 			<PlayerRoster bind:players />
 		</div>
 
 		<!-- Keep the original controls visible only on large screens (desktop) -->
 		<div class="hidden lg:block">
-			<PlayerMovementControls onMove={handlePlayerMove} />
+			<PlayerMovementControls />
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Move keyboard and pointer direction handling out of the component
into the shared playerState module. The component now imports
playerState and delegates triggerMove, clearDirection, key handling,
and pressed-key clearing to that centralized store instead of
maintaining local activeDirections, pressedKeys, and key mapping.

This simplifies the component props (remove onMove handler) and
reduces duplicated state/logic, ensuring a single source of truth for
player movement and improving reusability and testability. UI button
classes now read active state from playerState.activeDirections.